### PR TITLE
Seed deterministic admin user

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,6 +25,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/database/seeders/AdminSeeder.php
+++ b/database/seeders/AdminSeeder.php
@@ -13,6 +13,15 @@ class AdminSeeder extends Seeder
      */
     public function run(): void
     {
-        User::factory(1)->create();
+        User::updateOrCreate(
+            [
+                'email' => 'admin@example.com',
+            ],
+            [
+                'name' => 'Administrator',
+                'password' => 'password',
+                'role' => 'Admin',
+            ]
+        );
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,5 +20,6 @@ class DatabaseSeeder extends Seeder
         //     'email' => 'test@example.com',
         // ]);
         Genre::factory()->count(5)->create();
+        $this->call(AdminSeeder::class);
     }
 }


### PR DESCRIPTION
## Summary
- allow the User model to accept a role during mass assignment
- replace the admin factory call with an updateOrCreate seeder that ensures a consistent admin account
- invoke the admin seeder from the main database seeder so it runs with other seeders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f16a9a0c8320873c5315db937902