### PR TITLE
Add tag management API endpoints and tests

### DIFF
--- a/app/Http/Controllers/Book/TagController.php
+++ b/app/Http/Controllers/Book/TagController.php
@@ -4,14 +4,52 @@ namespace App\Http\Controllers\Book;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ImportRequest;
+use App\Http\Requests\Tag\StoreTagRequest;
+use App\Http\Requests\Tag\UpdateTagRequest;
+use App\Http\Resources\TagResource;
 use App\Imports\TagImport;
+use App\Models\Tag;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Maatwebsite\Excel\Facades\Excel;
 
 class TagController extends Controller
 {
+    public function index(): AnonymousResourceCollection
+    {
+        return TagResource::collection(Tag::query()->orderBy('name')->get());
+    }
+
+    public function show(Tag $tag): TagResource
+    {
+        return TagResource::make($tag);
+    }
+
+    public function store(StoreTagRequest $request): JsonResponse
+    {
+        $tag = Tag::create($request->validated());
+
+        return TagResource::make($tag)->response()->setStatusCode(201);
+    }
+
+    public function update(UpdateTagRequest $request, Tag $tag): TagResource
+    {
+        $tag->update($request->validated());
+
+        return TagResource::make($tag);
+    }
+
+    public function destroy(Tag $tag): JsonResponse
+    {
+        $tag->delete();
+
+        return response()->noContent();
+    }
+
     public function import(ImportRequest $request)
     {
         Excel::import(new TagImport, $request->file('file'));
+
         return response()->json(['message' => 'Импорт успешно завершён']);
     }
 }

--- a/app/Http/Requests/Tag/StoreTagRequest.php
+++ b/app/Http/Requests/Tag/StoreTagRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', 'unique:tags,name'],
+        ];
+    }
+}

--- a/app/Http/Requests/Tag/UpdateTagRequest.php
+++ b/app/Http/Requests/Tag/UpdateTagRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateTagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $tag = $this->route('tag');
+        $tagId = is_object($tag) ? $tag->getKey() : $tag;
+
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('tags', 'name')->ignore($tagId),
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/TagResource.php
+++ b/app/Http/Resources/TagResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TagResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+        ];
+    }
+}

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tag>
+ */
+class TagFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,9 +59,14 @@ Route::get('/books/top', [BookController::class, 'top']);
 Route::get('/books/{book}/comments', [CommentController::class, 'index']);
 Route::get('/guest/{id}', [UserController::class, 'guest']);
 Route::get('/genres', [GenreController::class, 'index']);
+Route::get('/tags', [TagController::class, 'index']);
+Route::get('/tags/{tag}', [TagController::class, 'show']);
 Route::middleware(['auth:sanctum', 'admin'])->group(function () {
     Route::post('/genres/import', [GenreController::class, 'import']);
     Route::post('/tags/import', [TagController::class, 'import']);
+    Route::post('/tags', [TagController::class, 'store']);
+    Route::match(['put', 'patch'], '/tags/{tag}', [TagController::class, 'update']);
+    Route::delete('/tags/{tag}', [TagController::class, 'destroy']);
     Route::post('/book-tags/import', [BookTagController::class, 'import']);
     Route::post('/books/import', [BookController::class, 'import']);
     Route::post('/books', [BookController::class, 'store']);

--- a/tests/Feature/Tag/TagControllerTest.php
+++ b/tests/Feature/Tag/TagControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Tag;
+
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TagControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_tags(): void
+    {
+        Tag::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/tags');
+
+        $response->assertOk()->assertJsonCount(3, 'data');
+    }
+
+    public function test_can_show_a_tag(): void
+    {
+        $tag = Tag::factory()->create();
+
+        $response = $this->getJson("/api/tags/{$tag->id}");
+
+        $response->assertOk()->assertJsonPath('data.id', $tag->id);
+    }
+
+    public function test_admin_can_create_tag(): void
+    {
+        Sanctum::actingAs(User::factory()->create(['role' => 'Admin']));
+
+        $response = $this->postJson('/api/tags', [
+            'name' => 'New Tag',
+        ]);
+
+        $response->assertCreated()->assertJsonPath('data.name', 'New Tag');
+
+        $this->assertDatabaseHas('tags', [
+            'name' => 'New Tag',
+        ]);
+    }
+
+    public function test_admin_can_update_tag(): void
+    {
+        $tag = Tag::factory()->create();
+        Sanctum::actingAs(User::factory()->create(['role' => 'Admin']));
+
+        $response = $this->putJson("/api/tags/{$tag->id}", [
+            'name' => 'Updated Tag',
+        ]);
+
+        $response->assertOk()->assertJsonPath('data.name', 'Updated Tag');
+
+        $this->assertDatabaseHas('tags', [
+            'id' => $tag->id,
+            'name' => 'Updated Tag',
+        ]);
+    }
+
+    public function test_admin_can_delete_tag(): void
+    {
+        $tag = Tag::factory()->create();
+        Sanctum::actingAs(User::factory()->create(['role' => 'Admin']));
+
+        $response = $this->deleteJson("/api/tags/{$tag->id}");
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseMissing('tags', [
+            'id' => $tag->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add store and update form requests to validate tag payloads
- introduce a dedicated TagResource for consistent API responses
- expand the tag controller, routes, factory, and feature tests to cover CRUD operations

## Testing
- not run (composer install requires GitHub authentication in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e23d70c2508320a84c317df18c96e6