### PR TITLE
Add genre CRUD API support

### DIFF
--- a/app/Http/Controllers/Book/GenreController.php
+++ b/app/Http/Controllers/Book/GenreController.php
@@ -3,11 +3,13 @@
 namespace App\Http\Controllers\Book;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Genre\StoreGenreRequest;
+use App\Http\Requests\Genre\UpdateGenreRequest;
 use App\Http\Requests\ImportRequest;
 use App\Http\Resources\GenreResource;
 use App\Imports\GenresImport;
 use App\Models\Genre;
-use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Maatwebsite\Excel\Facades\Excel;
 
 class GenreController extends Controller
@@ -15,11 +17,42 @@ class GenreController extends Controller
     public function index()
     {
         $genres = Genre::all();
+
         return GenreResource::collection($genres);
     }
+
+    public function show(Genre $genre)
+    {
+        return new GenreResource($genre);
+    }
+
+    public function store(StoreGenreRequest $request)
+    {
+        $genre = Genre::create($request->validated());
+
+        return (new GenreResource($genre))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function update(UpdateGenreRequest $request, Genre $genre)
+    {
+        $genre->update($request->validated());
+
+        return new GenreResource($genre);
+    }
+
+    public function destroy(Genre $genre)
+    {
+        $genre->delete();
+
+        return response()->noContent();
+    }
+
     public function import(ImportRequest $request)
     {
         Excel::import(new GenresImport, $request->file('file'));
+
         return response()->json(['message' => 'Импорт успешно завершён']);
     }
 }

--- a/app/Http/Requests/Genre/StoreGenreRequest.php
+++ b/app/Http/Requests/Genre/StoreGenreRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Genre;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreGenreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('genres', 'name'),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Genre/UpdateGenreRequest.php
+++ b/app/Http/Requests/Genre/UpdateGenreRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Genre;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateGenreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('genres', 'name')->ignore($this->route('genre')),
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/GenreResource.php
+++ b/app/Http/Resources/GenreResource.php
@@ -15,8 +15,10 @@ class GenreResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-          'name'=>$this->name,
-          'id'=>$this->id
+            'id' => $this->id,
+            'name' => $this->name,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,7 +59,11 @@ Route::get('/books/top', [BookController::class, 'top']);
 Route::get('/books/{book}/comments', [CommentController::class, 'index']);
 Route::get('/guest/{id}', [UserController::class, 'guest']);
 Route::get('/genres', [GenreController::class, 'index']);
+Route::get('/genres/{genre}', [GenreController::class, 'show']);
 Route::middleware(['auth:sanctum', 'admin'])->group(function () {
+    Route::post('/genres', [GenreController::class, 'store']);
+    Route::match(['put', 'patch'], '/genres/{genre}', [GenreController::class, 'update']);
+    Route::delete('/genres/{genre}', [GenreController::class, 'destroy']);
     Route::post('/genres/import', [GenreController::class, 'import']);
     Route::post('/tags/import', [TagController::class, 'import']);
     Route::post('/book-tags/import', [BookTagController::class, 'import']);

--- a/tests/Feature/Genre/GenreCrudTest.php
+++ b/tests/Feature/Genre/GenreCrudTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Genre;
+
+use App\Models\Genre;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class GenreCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_can_view_a_single_genre(): void
+    {
+        $genre = Genre::factory()->create();
+
+        $response = $this->getJson("/api/genres/{$genre->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $genre->id)
+            ->assertJsonPath('data.name', $genre->name);
+    }
+
+    public function test_admin_can_create_genre(): void
+    {
+        $admin = User::factory()->create(['role' => 'Admin']);
+        Sanctum::actingAs($admin);
+
+        $payload = ['name' => 'Science Fiction'];
+
+        $response = $this->postJson('/api/genres', $payload);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.name', $payload['name']);
+
+        $this->assertDatabaseHas('genres', $payload);
+    }
+
+    public function test_store_requires_name(): void
+    {
+        $admin = User::factory()->create(['role' => 'Admin']);
+        Sanctum::actingAs($admin);
+
+        $response = $this->postJson('/api/genres', []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('name');
+    }
+
+    public function test_admin_can_update_genre(): void
+    {
+        $admin = User::factory()->create(['role' => 'Admin']);
+        Sanctum::actingAs($admin);
+
+        $genre = Genre::factory()->create(['name' => 'History']);
+        $payload = ['name' => 'World History'];
+
+        $response = $this->putJson("/api/genres/{$genre->id}", $payload);
+
+        $response->assertOk()
+            ->assertJsonPath('data.name', $payload['name']);
+
+        $this->assertDatabaseHas('genres', [
+            'id' => $genre->id,
+            'name' => $payload['name'],
+        ]);
+    }
+
+    public function test_non_admin_cannot_modify_genres(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/genres', ['name' => 'Drama']);
+
+        $response->assertForbidden();
+    }
+
+    public function test_admin_can_delete_genre(): void
+    {
+        $admin = User::factory()->create(['role' => 'Admin']);
+        Sanctum::actingAs($admin);
+
+        $genre = Genre::factory()->create();
+
+        $response = $this->deleteJson("/api/genres/{$genre->id}");
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseMissing('genres', ['id' => $genre->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated form requests for creating and updating genres with validation rules
- extend the genre resource and controller with full CRUD endpoints
- secure and expose new genre routes and cover them with feature tests

## Testing
- php artisan test --testsuite=Feature *(fails: vendor directory missing because Composer dependencies require GitHub credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23d7239208320a7d13530ccf0851b