### PR TITLE
Validate AI recommendations and return tagged books

### DIFF
--- a/app/Http/Controllers/AI/RecommendationController.php
+++ b/app/Http/Controllers/AI/RecommendationController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers\AI;
 
 use App\Http\Controllers\Controller;
+use App\Models\Book;
 use App\Models\Tag;
 use App\Services\GeminiService;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 
 class RecommendationController extends Controller
@@ -43,6 +43,64 @@ class RecommendationController extends Controller
         Log::info('Отправка запроса к Gemini');
         $response = $gemini->predict($prompt);
         Log::info('Получен ответ от Gemini: ' . $response);
-        return response()->json(['tags' => $response]);
+
+        $decodedResponse = json_decode($response, true);
+        if (json_last_error() !== JSON_ERROR_NONE || !is_array($decodedResponse)) {
+            Log::error('Ошибка парсинга ответа Gemini', [
+                'response' => $response,
+                'error' => json_last_error_msg(),
+            ]);
+
+            return response()->json([
+                'message' => 'Некорректный ответ от сервиса рекомендаций.',
+            ], 502);
+        }
+
+        $tagsFromAi = array_values(array_filter($decodedResponse, function ($value) {
+            return is_string($value) && $value !== '';
+        }));
+
+        if (empty($tagsFromAi) || count($tagsFromAi) !== count($decodedResponse)) {
+            Log::error('Ответ Gemini не содержит валидный список тэгов', [
+                'response' => $decodedResponse,
+            ]);
+
+            return response()->json([
+                'message' => 'Сервис рекомендаций вернул неверный формат данных.',
+            ], 502);
+        }
+
+        $uniqueTags = array_values(array_unique($tagsFromAi));
+
+        try {
+            $books = Book::with('tags')
+                ->whereHas('tags', function ($query) use ($uniqueTags) {
+                    $query->whereIn('name', $uniqueTags);
+                }, '=', count($uniqueTags))
+                ->get()
+                ->map(function (Book $book) {
+                    return [
+                        'id' => $book->id,
+                        'title' => $book->title,
+                        'description' => $book->description,
+                        'author' => $book->author,
+                        'tags' => $book->tags->pluck('name')->all(),
+                    ];
+                })
+                ->values();
+        } catch (\Throwable $exception) {
+            Log::error('Ошибка при поиске книг по тэгам', [
+                'exception' => $exception,
+            ]);
+
+            return response()->json([
+                'message' => 'Не удалось получить рекомендации по тэгам.',
+            ], 500);
+        }
+
+        return response()->json([
+            'tags' => $uniqueTags,
+            'books' => $books,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- decode and validate the Gemini service response into a non-empty list of tag strings with error handling and logging
- query books that contain all recommended tags and eager load tag relations
- return structured JSON containing the requested tags and matching books, logging failures where appropriate

## Testing
- php -l app/Http/Controllers/AI/RecommendationController.php

------
https://chatgpt.com/codex/tasks/task_e_68e29671e5508320ad8cb84f4403e255