### PR TITLE
Update NLP controller to return tag and book resources

### DIFF
--- a/app/Http/Controllers/AI/NplController.php
+++ b/app/Http/Controllers/AI/NplController.php
@@ -4,6 +4,9 @@ namespace App\Http\Controllers\AI;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\NplRequest;
+use App\Http\Resources\BookResource;
+use App\Http\Resources\TagResource;
+use App\Models\Book;
 use App\Models\Tag;
 use App\Services\GeminiService;
 use Illuminate\Support\Facades\Log;
@@ -14,17 +17,45 @@ class NplController extends Controller
         $data = $request->validated();
         $tags = Tag::all()->pluck('name')->filter()->values()->toArray();
         $tagsString = empty($tags) ? null : '["' . implode('", "', $tags) . '"]';
-        $prompt = "
-Пользователь написал: \"{$data['text']}\"\n";
+        $prompt = "Ты — помощник библиотеки, который подбирает тэги по пользовательскому запросу.\n";
+        $prompt .= "Пользователь написал: \"{$data['text']}\"\n";
+
         if ($tagsString === null) {
-            $prompt .= "Список тэгов пуст. Сообщи пользователю, что подходящие тэги недоступны и посоветуй уточнить запрос позже.";
+            $prompt .= "Список доступных тэгов пуст.";
+            $prompt .= "\nОтветь строго валидным JSON-массивом []. Никаких пояснений, текста до или после массива не добавляй.";
         } else {
-            $prompt .= "Список тэгов: {$tagsString}\nВыбери подходящие тэги из списка. Ответь только тэгами через запятую:";
+            $prompt .= "Список доступных тэгов: {$tagsString}.";
+            $prompt .= "\nВыбери подходящие тэги из списка и ответь строго валидным JSON-массивом с названиями выбранных тэгов (например, [\"фантастика\",\"детектив\"]). Никаких пояснений, текста до или после массива не добавляй.";
         }
         Log::info('Отправка запроса к Gemini');
         $response = $gemini->predict($prompt);
         Log::info('Получен ответ от Gemini: ' . $response);
-        return response()->json(['tags' => $response]);
+
+        $tagNames = json_decode($response, true);
+        if (!is_array($tagNames)) {
+            $tagNames = [];
+        }
+
+        $tagsCollection = Tag::whereIn('name', $tagNames)->get();
+        $tagIds = $tagsCollection->pluck('id');
+
+        $books = collect();
+        if ($tagIds->isNotEmpty()) {
+            $books = Book::query()
+                ->whereHas(
+                    'tags',
+                    fn ($query) => $query->whereIn('tags.id', $tagIds),
+                    '=',
+                    $tagIds->count()
+                )
+                ->limit(10)
+                ->get();
+        }
+
+        return response()->json([
+            'tags' => TagResource::collection($tagsCollection)->resolve(),
+            'books' => BookResource::collection($books)->resolve(),
+        ]);
     }
 
 }


### PR DESCRIPTION
## Summary
- request Gemini for tag suggestions as a JSON array and parse the response safely
- look up selected tags and related books, returning structured tag and book resources in the response

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e2b86578bc832081461f397f932035