### PR TITLE
Add admin reservation filtering by user name

### DIFF
--- a/app/Http/Controllers/Admin/ReservationController.php
+++ b/app/Http/Controllers/Admin/ReservationController.php
@@ -9,9 +9,27 @@ use Illuminate\Http\Request;
 
 class ReservationController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        $reservations = Reservation::orderByDesc('updated_at')->paginate(20);
+        $reservationsQuery = Reservation::with(['book', 'user'])
+            ->orderByDesc('updated_at');
+
+        $search = trim((string) $request->input('user'));
+
+        if ($search !== '') {
+            $terms = preg_split('/\s+/', $search, -1, PREG_SPLIT_NO_EMPTY);
+
+            $reservationsQuery->whereHas('user', function ($query) use ($terms) {
+                foreach ($terms as $term) {
+                    $query->where('name', 'like', "%{$term}%");
+                }
+            });
+
+            $reservations = $reservationsQuery->get();
+        } else {
+            $reservations = $reservationsQuery->paginate(20);
+        }
+
         return ReservationResource::collection($reservations);
     }
 }


### PR DESCRIPTION
## Summary
- allow admin reservation listing to accept an optional user name filter
- ensure search matches all provided name fragments and returns only the target user's reservations

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f796f8d48320940e02eb73735b07